### PR TITLE
updating to support RGBA32F and EXT_color_buffer_float

### DIFF
--- a/core/host/CaptureContext.js
+++ b/core/host/CaptureContext.js
@@ -278,6 +278,7 @@ define([
         // the proper places, such as Info.js for enum values and the resource
         // system for new resources
         var validExts = [
+            'EXT_color_buffer_float',
             'GLI_frame_terminator',
             'OES_texture_float',
             'OES_texture_half_float',

--- a/core/shared/Info.js
+++ b/core/shared/Info.js
@@ -231,6 +231,8 @@ define([
         "RGBA16I",
         "RGBA32I",
         "RGBA32UI",
+        "RGBA16F",
+        "RGBA32F"
     ];
     const depthRenderableFormats = [
         "DEPTH_COMPONENT16",

--- a/core/shared/TextureInfo.js
+++ b/core/shared/TextureInfo.js
@@ -79,8 +79,8 @@ define([
         t[glc.RGB5_A1]            = { colorType: "0-1",   format: glc.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4, 2, 4],  type: [glc.UNSIGNED_BYTE, glc.UNSIGNED_SHORT_5_5_5_1, glc.UNSIGNED_INT_2_10_10_10_REV], };
         t[glc.RGBA4]              = { colorType: "0-1",   format: glc.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement: [4, 2],     type: [glc.UNSIGNED_BYTE, glc.UNSIGNED_SHORT_4_4_4_4], };
         t[glc.RGB10_A2]           = { colorType: "0-1",   format: glc.RGBA,            colorRenderable: true,  textureFilterable: true,  bytesPerElement:  4,         type: glc.UNSIGNED_INT_2_10_10_10_REV, };
-        t[glc.RGBA16F]            = { colorType: "float", format: glc.RGBA,            colorRenderable: false, textureFilterable: true,  bytesPerElement: [8, 16],    type: [glc.HALF_FLOAT, glc.FLOAT], };
-        t[glc.RGBA32F]            = { colorType: "float", format: glc.RGBA,            colorRenderable: false, textureFilterable: false, bytesPerElement: 16,         type: glc.FLOAT, };
+        t[glc.RGBA16F]            = { colorType: "float", format: glc.RGBA,            colorRenderable: true, textureFilterable: true,  bytesPerElement: [8, 16],    type: [glc.HALF_FLOAT, glc.FLOAT], };
+        t[glc.RGBA32F]            = { colorType: "float", format: glc.RGBA,            colorRenderable: true, textureFilterable: false, bytesPerElement: 16,         type: glc.FLOAT, };
         t[glc.RGBA8UI]            = { colorType: "uint",  format: glc.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement:  4,         type: glc.UNSIGNED_BYTE, };
         t[glc.RGBA8I]             = { colorType: "int",   format: glc.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement:  4,         type: glc.BYTE, };
         t[glc.RGB10_A2UI]         = { colorType: "uint",  format: glc.RGBA_INTEGER,    colorRenderable: true,  textureFilterable: false, bytesPerElement:  4,         type: glc.UNSIGNED_INT_2_10_10_10_REV, };


### PR DESCRIPTION
I'm mostly creating this pull request for a place to discuss this issue/feature. How would I add `EXT_color_buffer_float` support? Even if this can't be merged into your branch, I need to fix it for my own project so I can debug.

I've added these changes, which prevent `gl.FRAMEBUFFER_INCOMPLETE_ATTACHMENT` errors from being thrown on `gl.checkFramebuffer()`.  However, I'm still getting the following errors:

```
const internalFormatInfo = textureInfo.getInternalFormatInfo(version.extras.format.internalFormat);

Uncaught TypeError: Cannot read property 'internalFormat' of undefined
    at TexturePreviewGenerator.draw (VM10542 TexturePreview.js:425)
    at SurfaceInspector.TextureView.inspector.updatePreview (TextureView.js:89)
    at SurfaceInspector.TextureView.inspector.setTexture (TextureView.js:117)
    at TextureView.setTexture (TextureView.js:734)
    at Tab.<anonymous> (TexturesTab.js:116)
    at EventSource.fire (EventSource.js:38)
    at LeftListing.selectValue (LeftListing.js:125)
    at HTMLDivElement.el.onclick (LeftListing.js:85)
```

and 

```
if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
     gl.linkProgram(program);
}   

Uncaught TypeError: Failed to execute 'getProgramParameter' on 'WebGL2RenderingContext': parameter 1 is not of type 'WebGLProgram'.
    at StateSnapshot.apply (StateSnapshot.js:290)
    at Frame.makeActive (Frame.js:395)
    at RedundancyChecker.run (RedundancyChecker.js:822)
    at TraceView.setFrame (TraceView.js:433)
    at Tab.<anonymous> (TraceTab.js:52)
    at EventSource.fire (EventSource.js:38)
    at LeftListing.selectValue (LeftListing.js:125)
    at Window.appendFrame (Window.js:355)
    at CaptureContext.captureCallback (HostUI.js:26)
    at stopCapturing (CaptureContext.js:58)
```